### PR TITLE
Naprawiono implementację algorytmu quicksort

### DIFF
--- a/quicksort.pl
+++ b/quicksort.pl
@@ -1,6 +1,6 @@
 % Implementacja Quicksorta w Prologu
 % Autor korpo, https://github.com/korpo
-
+project_dedalus_quicksort([],[]).
 project_dedalus_quicksort([X],[X]).
 project_dedalus_quicksort([X|Xs],Ys) :-
   project_dedalus_quicksort_helper_partition(Xs,X,Left,Right),


### PR DESCRIPTION
Algorytm nie uwzględniał przypadku, gdy oba argumenty funkcji `project_dedalus_quicksort` były pustymi listami.